### PR TITLE
Update cmd.c

### DIFF
--- a/kernel/src/cmd.c
+++ b/kernel/src/cmd.c
@@ -4,15 +4,15 @@
 #include <klib.h>
 #include <shell.h>
 
-// cmd_num 需要手动改！！！！！！
-#define CMDNUM 8
 static char *cmd_list[] = {"ls",  "cd",    "pwd",   "mkdir",
                            "cat", "touch", "rmdir", "rm"};
+#define CMDNUM \
+    ( sizeof(cmd_list) / sizeof(cmd_list[0]) )
 enum CMD_LIST { LS = 0, CD, PWD, MKDIR, CAT, TOUCH, RMDIR, RM };
 
 extern inode_t *itable[];
 
-int cmd_parse(char *input, char *output) {
+int cmd_parse(char *input, char output[128]) {
   memset(output, '\0', sizeof(output));
   char *tmp_cmd = pmm->alloc(128);
   strcpy(tmp_cmd, input);


### PR DESCRIPTION
Support auto-adjust CMDNUM
`#define CMDNUM \`
`    ( sizeof(cmd_list) / sizeof(cmd_list[0]) )`
Fix a potential bug.
origin
`char* output`
edit into
`char output[128]`
Because in origin line 16
`sizeof(output)` is calculated when compiling, so output is considered as a normal pointer of char, so sizeof(output) will be equals to sizeof(void*)

But you should be aware of using this method, since 128 may not match its caller. Some compilers and IDEs can help you check, but you can consider this safer way
caller
`char* text=NULL;`
`cmd_parse(line,&text);`
`//output with text`
`free(text);`
cmd_parse
`cmd_parse(char *input,char **output){`
`*output=alloc(/*size you need*/);//Edit the pointer in the caller to where is about to contain output information`
So that the only constant you need to consider is in cmd_parse